### PR TITLE
Fixed a bug with the utf8 word "Array" in a buffer causing a crash.

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,9 +26,7 @@ ConcatStream.prototype.arrayConcat = function(arrs) {
 }
 
 ConcatStream.prototype.isArray = function(arr) {
-  var isArray = Array.isArray(arr)
-  var isTypedArray = arr.toString().match(/Array/)
-  return isArray || isTypedArray
+  return Array.isArray(arr)
 }
 
 ConcatStream.prototype.getBody = function () {

--- a/test.js
+++ b/test.js
@@ -19,10 +19,10 @@ arrays.end()
 
 // buffer stream
 var buffers = concat(function(err, out) {
-  console.log('buffers', err, out)
+  console.log('buffers', err, out.toString())
 })
-buffers.write(new Buffer('pizza '))
-buffers.write(new Buffer('cats'))
+buffers.write(new Buffer('pizza Array is not a ', 'utf8'))
+buffers.write(new Buffer('stringy cat'))
 buffers.end()
 
 // string stream


### PR DESCRIPTION
Putting the word "Array" in a utf8 buffer causes the program to crash.

``` javascript
var buffers = concat(function(err, out) {
  console.log('buffers', err, out.toString())
})
buffers.write(new Buffer('pizza Array is not a ', 'utf8'))
buffers.write(new Buffer('stringy cat'))
buffers.end()
```

This is a possible security vulnerability for servers using this library to process requests.
