### PR TITLE
Use readable-stream for backwards compatibility with node 0.8

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var Writable = require('stream').Writable
+var Writable = require('readable-stream').Writable
 var inherits = require('inherits')
 var TA = require('typedarray')
 var U8 = typeof Uint8Array !== 'undefined' ? Uint8Array : TA.Uint8Array
@@ -14,7 +14,7 @@ function ConcatStream(opts, cb) {
 
   var encoding = opts.encoding
   var shouldInferEncoding = false
-  
+
   if (!encoding) {
     shouldInferEncoding = true
   } else {
@@ -23,7 +23,7 @@ function ConcatStream(opts, cb) {
       encoding = 'uint8array'
     }
   }
-  
+
   Writable.call(this, { objectMode: true })
 
   this.encoding = encoding

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "http://github.com/maxogden/node-concat-stream/issues"
   },
   "engines": [
-    "node >= 0.10.0"
+    "node >= 0.8"
   ],
   "main": "index.js",
   "scripts": {
@@ -26,7 +26,8 @@
   "license": "MIT",
   "dependencies": {
     "inherits": "~2.0.1",
-    "typedarray": "~0.0.5"
+    "typedarray": "~0.0.5",
+    "readable-stream": "~1.1.9"
   },
   "devDependencies": {
     "tape": "~2.3.2"


### PR DESCRIPTION
Also fixes https://github.com/substack/coverify/issues/4

This simple change means people who are using your module (or something that depends on it) have a clear upgrade path from their old version of node to a new one.
