### PR TITLE
Fixed "no data" case when an encoding is specified

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ ConcatStream.prototype.inferEncoding = function (buff) {
 }
 
 ConcatStream.prototype.getBody = function () {
-  if (this.body.length === 0) return []
+  if (!this.encoding && this.body.length === 0) return []
   if (this.shouldInferEncoding) this.encoding = this.inferEncoding()
   if (this.encoding === 'array') return arrayConcat(this.body)
   if (this.encoding === 'string') return stringConcat(this.body)

--- a/test/nothing.js
+++ b/test/nothing.js
@@ -15,3 +15,11 @@ test('no encoding set, no data', function (t) {
   })
   stream.end()
 })
+
+test('encoding set to string, no data', function (t) {
+  var stream = concat({ encoding: 'string' }, function(data) {
+    t.deepEqual(data, '')
+    t.end()
+  })
+  stream.end()
+})


### PR DESCRIPTION
When an encoding of "string" is specified, and no data a set, an empty string is expected.

This  bug was introduced by https://github.com/maxogden/concat-stream/commit/afff9d06f5d210b13f6392cb0141715a3e1ef983. The intent of that commit was to return an array when there was no data and no encoding, however it never actually checked that there wasn't an encoding.
