### PR TITLE
Correctly infer string encoding from empty string

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,8 +42,7 @@ ConcatStream.prototype._write = function(chunk, enc, next) {
 }
 
 ConcatStream.prototype.inferEncoding = function (buff) {
-  var firstBuffer = buff || this.body[0]
-  if (!firstBuffer) return 'buffer'
+  var firstBuffer = buff === undefined ? this.body[0] : buff;
   if (Buffer.isBuffer(firstBuffer)) return 'buffer'
   if (typeof Uint8Array !== 'undefined' && firstBuffer instanceof Uint8Array) return 'uint8array'
   if (Array.isArray(firstBuffer)) return 'array'

--- a/test/infer.js
+++ b/test/infer.js
@@ -8,6 +8,7 @@ test('type inference works as expected', function(t) {
   t.equal(stream.inferEncoding(undefined), 'buffer', 'buffer')
   t.equal(stream.inferEncoding(new Uint8Array(1)), 'uint8array', 'uint8array')
   t.equal(stream.inferEncoding('hello'), 'string', 'string')
+  t.equal(stream.inferEncoding(''), 'string', 'string')
   t.equal(stream.inferEncoding({hello: "world"}), 'object', 'object')
   t.equal(stream.inferEncoding(1), 'buffer', 'buffer')
   t.end()

--- a/test/string.js
+++ b/test/string.js
@@ -62,3 +62,15 @@ test('string from buffers with multibyte characters', function (t) {
   }
   strings.end()
 })
+
+test('string infer encoding with empty string chunk', function (t) {
+  t.plan(2)
+  var strings = concat(function(out) {
+    t.equal(typeof out, 'string')
+    t.equal(out, 'nacho dogs')
+  })
+  strings.write("")
+  strings.write("nacho ")
+  strings.write("dogs")
+  strings.end()
+})


### PR DESCRIPTION
## Use Case

I have an issue where sometimes the first chunk of my **stream of strings** is an empty string and _concat-stream_ then treats the stream as if it were a **stream of buffers**.

``` javascript
var concat = require("concat-stream");
var strings = concat(function(data) {
  console.log(typeof data === "string");
  // -> sometimes `false`, sometimes `true`
});
if (Math.random() > 0.5) strings.write("");
strings.end("foo bar");
```
## Changes

This change handles the case where the first chunk written is an empty string (`''`) and correctly infers the encoding to be `'string'` instead of `'buffer'`. All original tests pass without change and I've added new tests for this behavior.
### Details

The bug was with this falsey check in the `inferEncoding` function:

``` javascript
if (!firstBuffer) return 'buffer'
```

The empty string was matching this case. I've removed this case which allows the `typeof firstBuffer === 'string'` case to match. Other falsey values will still fall through all other cases and hit `return 'buffer'` at the end of the function. 
