### PR TITLE
Remove unused `isArray` polyfill

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,10 +66,6 @@ ConcatStream.prototype.getBody = function () {
   return this.body
 }
 
-var isArray = Array.isArray || function (arr) {
-  return Object.prototype.toString.call(arr) == '[object Array]'
-}
-
 function isArrayish (arr) {
   return /Array\]$/.test(Object.prototype.toString.call(arr))
 }


### PR DESCRIPTION
Not being used anywhere. Or, should it be used [here](https://github.com/maxogden/concat-stream/blob/9c14e0eb65c966a307afc4f73e0f905dcdc0a675/index.js#L48)?
